### PR TITLE
feat(lab-deltas): delta staging scaffold + first manual delta

### DIFF
--- a/lab-deltas/.manifest.json
+++ b/lab-deltas/.manifest.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Last-processed HEAD SHA per tracked repo (keyed by nameWithOwner). Drives incremental delta collection. Topic management is IaC-owned (Terraform/OpenTofu); this manifest only records progress, not the tracked-repo list.",
+  "repos": {
+    "giacchetta/openclaw-a2a-bridge": {
+      "lastProcessedSha": "5e428c02d59db234a8cd90a44a5f1bfc27e1e592",
+      "lastProcessedDate": "2026-08-01",
+      "defaultBranch": "main"
+    }
+  }
+}

--- a/lab-deltas/2026-08-02.md
+++ b/lab-deltas/2026-08-02.md
@@ -1,0 +1,133 @@
+# Lab Delta — 2026-08-02
+
+> Consolidated raw delta for the week ending 2026-08-02.
+> Source: `gh repo list giacchetta --topic lab` (1 repo tracked).
+> Format: text-only, no emojis. This is raw material for the LinkedIn post,
+> not the post itself.
+
+---
+
+## Repo: giacchetta/openclaw-a2a-bridge
+
+- Default branch: `main`
+- Range: `50a403f` (root, 2026-07-28) .. `5e428c0` (HEAD, 2026-08-01)
+- Note: this repo was created on 2026-07-28, so this delta covers its entire
+  history from the initial commit. The last published blog post was
+  2026-07-19 ("Architecting the Headless Cognitive State Machine"), which
+  described the bridge as routing "via child process to the OpenClaw CLI" —
+  that path was later found to be broken (fire-and-forget; see below).
+
+### Commits (root .. HEAD)
+
+- `50a403f` 2026-07-28  Initial working version
+- `ba13665` 2026-08-01  Fix/coder parity researcher template (#4)
+- `e8ffd6c` 2026-08-01  feat(researcher): reviewer delegates code work to Coder over A2A (#5)
+- `a4115e4` 2026-08-01  docs: sync AGENTS.md + README.md with Phase 2 (Issue #3)
+- `5e428c0` 2026-08-01  fix(readme): repair broken Mermaid diagram (invalid -.x arrow syntax)
+
+### Files changed (root .. HEAD)
+
+- M  .gitignore
+- M  AGENTS.md
+- M  README.md
+- M  agents/coder/.openclaw/openclaw.json
+- M  agents/coder/.openclaw/workspace/IDENTITY.md
+- M  agents/researcher/.openclaw/workspace/IDENTITY.md
+- M  agents/researcher/.openclaw/workspace/reviewer/IDENTITY.md
+
+### AGENTS.md diff (summary)
+
+Diffstat: 35 +++++++++++++++ 8 ---- (net +27 lines). Key changes:
+
+1. **"Last updated" bumped** 2026-07-27 -> 2026-08-01.
+
+2. **§8 Cognitive Engine — new "Researcher reviewer — A2A code delegation
+   (prompt-based, pending enforcement)" blockquote.** Documents that the
+   Researcher's reviewer/IDENTITY.md carries an "A2A Code Delegation" directive
+   (POST a code spec to the Coder at http://coder:3000/a2a/tasks, fold Coder's
+   result.output into the synthesized deliverable, one-way + code-only). Adds a
+   status note: end-to-end testing (2026-08-01) showed the directive does NOT
+   fire in practice — the reviewer's task-completion instinct overrides the
+   prompt-level "FORBIDDEN FROM WRITING CODE" rule, so it writes the code
+   itself and Coder's bridge never receives a delegation. Classified as an
+   agent-platform limitation (not a model limitation). Refs issues #6/#7/#8.
+
+3. **§8 — new "Orchestrator Guardrails (Researcher main)" subsection** with a
+   3-row table of guardrails in main/IDENTITY.md that fix early-termination
+   failure modes discovered during testing:
+   - TRUNCATED-OUTPUT RULE — forward truncated executor output straight to the
+     reviewer; do not retrieve/narrate/repair it.
+   - STEP 5->6 ATOMIC — sessions_spawn(reviewer) and sessions_yield must happen
+     back-to-back in the same turn (fixes the reviewer being orphaned).
+   - EXECUTOR ERROR / EMPTY-OUTPUT RULE — on executor error or empty output,
+     proceed to the reviewer with the blueprint + a failure note; no retry step.
+
+4. **§9 Fleet Inventory — sub-agent table expanded** with per-node tool access:
+   - main: exec/web_fetch DENIED (orchestrator-only router).
+   - planner: tools.profile "full".
+   - executor: tools.profile "full" (no deny list).
+   - reviewer: tools.profile "full" (no deny list); on Researcher carries the
+     pending-enforcement A2A code-delegation directive.
+   Adds a "Coder parity (Phase 1)" note: Coder's main is now an orchestrator-only
+   router matching Researcher; all Coder sub-agents have tools.profile "full";
+   planner id is lowercase to match sessions_spawn casing.
+
+5. **§11 Known Constraints — two new rows:**
+   - "Prompt-only A2A delegation does not fire" — proven across 4 end-to-end
+     tests (2026-08-01) with both reviewer and executor as the delegation point.
+     Pending structural enforcement; tracked in issues #6 (live with it),
+     #7 (plugin/extend OpenClaw), #8 (fork/build new runtime).
+   - "Orchestrator early-termination (mitigated, not fully solved)" — three
+     guardrails fix the known trigger paths; test 5 showed a residual
+     truncation-triggered case still possible; full reliability likely requires
+     the same structural enforcement as the delegation issue.
+
+### README.md diff (summary)
+
+Diffstat: 21 ++++++++++ 1 - (net +20 lines). Key changes:
+
+1. **Big-picture Mermaid flowchart — Researcher->Coder edge updated.**
+   Replaced the bidirectional `RES <--> COD` with a directional delegation edge:
+   - `RES -- "A2A code delegation<br/>(reviewer -> coder:3000)" --> COD`
+   - `COD -. "one-way only<br/>(Coder never calls back)" .-> RES`
+   Added a `classDef pending` (dashed, amber) applied to RES to mark the
+   delegation as not-yet-reliable. Added a warning note that the edge is the
+   intended design but pending enforcement (links to Known limitations).
+
+2. **Three-node loop section — new reviewer delegation note.** Added a
+   blockquote: on the Researcher, the reviewer carries an A2A code-delegation
+   directive (hand code work to Coder over the network instead of writing it
+   itself); intended design, pending enforcement.
+
+3. **New "Known limitations" section.** Two numbered items mirroring AGENTS.md
+   §11: (1) prompt-only A2A delegation does not fire (agent-platform limitation,
+   tracked in #6/#7/#8); (2) orchestrator early-termination mitigated but not
+   fully solved (three guardrails in place, residual truncation case in test 5).
+   Notes the guardrails are working and the planner->executor->reviewer loop now
+   completes; what's pending is the cross-agent delegation firing reliably.
+
+4. **Mermaid syntax fix (commit 5e428c0).** The first diagram used an invalid
+   `-.x` dotted-arrow-with-cross syntax for the one-way back-edge; mmdc v11.16.0
+   failed to parse it. Replaced with the valid `-. "text" .->` dotted-arrow-
+   with-text syntax. All 3 README Mermaid diagrams validated (exit 0).
+
+### Narrative notes for the post (not in the diff, from session context)
+
+- The Jul 19 post claimed the bridge "routes via child process to the OpenClaw
+  CLI." That path was the fire-and-forget CLI, which returns at acceptance
+  (not completion) and silently dropped sub-agent responses. The bridge was
+  redesigned to speak the Gateway WebSocket lifecycle directly (connect ->
+  agent -> subscribe to chat events -> wait for the main session's final
+  synthesized message under a resumed runId). This fix predates the root commit
+  (50a403f, "Initial working version") so it's part of the initial state, not a
+  diff — but it's the biggest story since the Jul 19 post and should lead the
+  narrative. See /memories/repo/a2a-bridge-gateway-ws.md for the full detail.
+- Coder was brought to parity with Researcher (orchestrator-only main, full
+  sub-agent tool access, lowercase planner id) — Phase 1.
+- Researcher->Coder A2A code delegation was wired (reviewer as delegator) and
+  tested end-to-end 5 times; it does not fire (agent-platform limitation). Three
+  GitHub issues opened for structural enforcement options (#6/#7/#8).
+- Three orchestrator guardrails added to Researcher main/IDENTITY.md to fix
+  early-termination failure modes.
+- Docs overhauled: AGENTS.md §8/§9/§11 + README.md (Mermaid diagrams, Known
+  limitations section); Mermaid syntax bug fixed.

--- a/lab-deltas/README.md
+++ b/lab-deltas/README.md
@@ -1,0 +1,50 @@
+# lab-deltas/
+
+Raw, text-only weekly deltas collected from tracked PoC/Lab repositories.
+This folder is a **staging ground** for the Lab Delta → LinkedIn Post pipeline.
+It is NOT part of the Astro content collections (lives at repo root, outside
+`src/content/`), so none of these files are rendered as site pages.
+
+## Purpose
+
+Every Saturday, a GitHub Action (`.github/workflows/lab-delta.yml`, planned)
+collects the week's changes from every repo tagged with the `lab` GitHub topic
+and consolidates them into a single `lab-deltas/<YYYY-MM-DD>.md` file here.
+The user then turns that raw delta into a polished LinkedIn post in
+`www_gianet_us/blog` (manually via the Gemini App for now; Copilot-in-Actions
+automation is under investigation).
+
+## File naming
+
+- `lab-deltas/<YYYY-MM-DD>.md` — the consolidated delta for the week ending on
+  that date (Saturday collection date). One file per week, covering ALL tracked
+  repos. No emojis, structured text only (this is raw material, not a post).
+- `lab-deltas/.manifest.json` — last-processed HEAD SHA per tracked repo, keyed
+  by `nameWithOwner`. Drives incremental collection (only new commits since the
+  last run are included).
+- `lab-deltas/PIPELINE.md` — pipeline documentation (both stages, Saturday
+  handoff, how to add a tracked repo).
+
+## Repo discovery
+
+Tracked repos are discovered dynamically via the `lab` GitHub topic:
+
+```bash
+gh repo list giacchetta --topic lab --json nameWithOwner,defaultBranchRef
+```
+
+**Topic management is owned by Terraform/OpenTofu (IaC).** This pipeline ONLY
+reads the `lab` topic; it never sets it. To add a new PoC repo to the pipeline,
+tag it `lab` in the IaC — the next Action run picks it up automatically (the
+manifest handles the first-run full-history case).
+
+## Currently tracked (as of 2026-08-01)
+
+- `giacchetta/openclaw-a2a-bridge` — A2A network PoC (OpenClaw + Apicurio).
+
+## Stage 2 (post generation) — deferred
+
+Turning a raw delta into a polished LinkedIn post is a manual step for now
+(Gemini App, included in Google Workspace). Automating it with Copilot
+inference directly from a GitHub Action is under investigation (subscription /
+per-inference billing question). See `PIPELINE.md` for the intended design.


### PR DESCRIPTION
## Summary

Adds the `lab-deltas/` staging scaffold for the **Lab Delta → LinkedIn Post pipeline** and the first manual delta. This is Phase 1 of a two-stage pipeline:

- **Stage 1 (this PR, manual)** — collect raw, text-only deltas from tracked PoC repos into `lab-deltas/<date>.md`. Phase 2 will automate this with a GitHub Action.
- **Stage 2 (deferred)** — turn a raw delta into a polished LinkedIn post in `www_gianet_us/blog`. Manual via the Gemini App for now; Copilot-in-Actions automation under investigation (subscription/billing question).

## What's in this PR

- `lab-deltas/README.md` — staging convention, repo discovery via the `lab` GitHub topic (**IaC-owned** via Terraform/OpenTofu; the pipeline only reads it), currently-tracked repos, and the deferred Stage 2.
- `lab-deltas/.manifest.json` — last-processed HEAD SHA per tracked repo (keyed by `nameWithOwner`). Seeded with `giacchetta/openclaw-a2a-bridge` @ `5e428c0` (2026-08-01). Drives incremental collection.
- `lab-deltas/2026-08-02.md` — first manual delta covering `openclaw-a2a-bridge` from root commit (`50a403f`, 2026-07-28) through HEAD (`5e428c0`, 2026-08-01): Coder parity, Researcher→Coder A2A delegation wiring + the agent-platform limitation finding (prompt-only delegation does not fire), orchestrator guardrails, AGENTS.md/README.md doc overhaul, Mermaid syntax fix.

## Safety

- `lab-deltas/` lives at repo root, **outside `src/content/`** — Astro never renders it. Confirmed statically via `src/content.config.ts` (all three collections `glob` from `./src/content/<subdir>` only).
- Commit includes `[skip ci]` — docs-only addition outside `src/`; no Astro build/deploy needed.

## Repo discovery (read-only)

\`\`\`bash
gh repo list giacchetta --topic lab --json nameWithOwner,defaultBranchRef
\`\`\`

Verified 2026-08-01: returns exactly one repo (`giacchetta/openclaw-a2a-bridge`). Topic management is IaC-owned; this pipeline never mutates topics.

## Follow-up (Phase 2, separate PR)

- `.github/workflows/lab-delta.yml` — weekly cron + `workflow_dispatch`; auto-commit with `[skip ci]`.
- `lab-deltas/PIPELINE.md` — full pipeline docs.

## Test plan

- [x] `lab-deltas/` is outside Astro content loader paths (static check of `content.config.ts`)
- [x] `gh repo list --topic lab` returns the tracked repo
- [x] Manifest seeded with the correct HEAD SHA
- [ ] CI build stays green (this commit is `[skip ci]`; next non-skip commit validates)